### PR TITLE
Update sag_wm_msr_dep.yaml to use 10.5

### DIFF
--- a/kubernetes/minikube/sag_wm_msr_dep.yaml
+++ b/kubernetes/minikube/sag_wm_msr_dep.yaml
@@ -18,7 +18,7 @@ spec:
       hostname: wm-msr
       containers:
       - name: wm-msr
-        image: store/softwareag/webmethods-microservicesruntime:10.3
+        image: store/softwareag/webmethods-microservicesruntime:10.5
         imagePullPolicy: Always
         ports:
         - containerPort: 5555


### PR DESCRIPTION
As 10.3 is not available on docker hub, updating it to use 10.5

If there is a way to make it always pull latest version, it would be nice.